### PR TITLE
Fix logging in debug mode

### DIFF
--- a/rainbow-cake-core/src/main/java/co/zsmb/rainbowcake/internal/logging/Logging.kt
+++ b/rainbow-cake-core/src/main/java/co/zsmb/rainbowcake/internal/logging/Logging.kt
@@ -8,14 +8,16 @@ import java.io.StringWriter
 @Suppress("unused")
 internal fun log(tag: String, message: String) {
     if (RainbowCakeConfiguration.isProd) {
-        RainbowCakeConfiguration.logger.log(tag, message)
+        return
     }
+    RainbowCakeConfiguration.logger.log(tag, message)
 }
 
 internal inline fun <reified T> T.log(tag: String, e: Throwable) {
     if (RainbowCakeConfiguration.isProd) {
-        log(tag, getStacktraceString(e))
+        return
     }
+    log(tag, getStacktraceString(e))
 }
 
 private fun getStacktraceString(e: Throwable): String {


### PR DESCRIPTION
[Based on your intentions](https://github.com/rainbowcake/rainbowcake/blob/dev/rainbow-cake-core/src/main/java/co/zsmb/rainbowcake/config/RainbowCakeConfigurator.kt#L16), the logging should be available only in _debug mode_.

But in the actual code, logging is only available in _production mode_:
- [`Logging.kt#L10`](https://github.com/rainbowcake/rainbowcake/blob/1.0.0-RELEASE/rainbow-cake-core/src/main/java/co/zsmb/rainbowcake/internal/logging/Logging.kt#L10)
- [`Logging.kt#L16`](https://github.com/rainbowcake/rainbowcake/blob/1.0.0-RELEASE/rainbow-cake-core/src/main/java/co/zsmb/rainbowcake/internal/logging/Logging.kt#L16)

This _PR_ fixes the inverted logging logic, which was introduced in the last _release_ ([RainbowCake 1.0.0](https://github.com/rainbowcake/rainbowcake/releases/tag/1.0.0-RELEASE)):
- https://github.com/rainbowcake/rainbowcake/commit/5c0325501ea9f006ac95de75834a87f5e158a274#diff-596e82120d5c362ea7daccb176f0ae8bL8