### PR TITLE
Support BottomSheet Dialog Fragments

### DIFF
--- a/demo/src/main/java/co/zsmb/rainbowcake/demo/ui/example/ExampleFragment.kt
+++ b/demo/src/main/java/co/zsmb/rainbowcake/demo/ui/example/ExampleFragment.kt
@@ -5,6 +5,7 @@ import android.view.View
 import co.zsmb.rainbowcake.base.RainbowCakeFragment
 import co.zsmb.rainbowcake.dagger.getViewModelFromFactory
 import co.zsmb.rainbowcake.demo.R
+import co.zsmb.rainbowcake.demo.ui.foo.FooBottomSheetFragment
 import co.zsmb.rainbowcake.demo.ui.foo.FooFragment
 import co.zsmb.rainbowcake.demo.ui.koin.KoinFragment
 import co.zsmb.rainbowcake.demo.ui.sharedvmpager.SharedVMPagerFragment
@@ -38,6 +39,10 @@ class ExampleFragment : RainbowCakeFragment<ExampleViewState, ExampleViewModel>(
 
         koinExampleDemoButton.setOnClickListener {
             navigator?.add(KoinFragment())
+        }
+
+        bottomSheetExampleDemoButton.setOnClickListener {
+            fragmentManager?.let { FooBottomSheetFragment().show(it, "FooBottomSheetFragment") }
         }
     }
 

--- a/demo/src/main/java/co/zsmb/rainbowcake/demo/ui/foo/FooBottomSheetFragment.kt
+++ b/demo/src/main/java/co/zsmb/rainbowcake/demo/ui/foo/FooBottomSheetFragment.kt
@@ -1,0 +1,22 @@
+package co.zsmb.rainbowcake.demo.ui.foo
+
+import co.zsmb.rainbowcake.base.RainbowCakeBottomFragment
+import co.zsmb.rainbowcake.dagger.getViewModelFromFactory
+import co.zsmb.rainbowcake.demo.R
+import kotlinx.android.synthetic.main.fragment_bottom_sheet_foo.fooBottomSheetFragmentText
+
+class FooBottomSheetFragment : RainbowCakeBottomFragment<FooViewState, FooViewModel>() {
+
+    override fun provideViewModel() = getViewModelFromFactory()
+    override fun getViewResource() = R.layout.fragment_bottom_sheet_foo
+    override fun onStart() {
+        super.onStart()
+
+        viewModel.load()
+    }
+
+    override fun render(viewState: FooViewState) {
+        fooBottomSheetFragmentText.text = viewState.data
+    }
+
+}

--- a/demo/src/main/java/co/zsmb/rainbowcake/demo/ui/foo/FooPresenter.kt
+++ b/demo/src/main/java/co/zsmb/rainbowcake/demo/ui/foo/FooPresenter.kt
@@ -6,7 +6,7 @@ import javax.inject.Inject
 class FooPresenter @Inject constructor() {
 
     suspend fun getData(): String = withIOContext {
-        ""
+        "Data"
     }
 
 }

--- a/demo/src/main/java/co/zsmb/rainbowcake/demo/ui/koin/KoinBottomSheetFragment.kt
+++ b/demo/src/main/java/co/zsmb/rainbowcake/demo/ui/koin/KoinBottomSheetFragment.kt
@@ -1,0 +1,22 @@
+package co.zsmb.rainbowcake.demo.ui.koin
+
+import co.zsmb.rainbowcake.base.RainbowCakeBottomFragment
+import co.zsmb.rainbowcake.demo.R
+import co.zsmb.rainbowcake.koin.getViewModelFromFactory
+import kotlinx.android.synthetic.main.fragment_bottom_sheet_foo.fooBottomSheetFragmentText
+
+class KoinBottomSheetFragment : RainbowCakeBottomFragment<KoinViewState, KoinViewModel>() {
+
+    override fun provideViewModel() = getViewModelFromFactory()
+    override fun getViewResource() = R.layout.fragment_bottom_sheet_foo
+    override fun onStart() {
+        super.onStart()
+
+        viewModel.load()
+    }
+
+    override fun render(viewState: KoinViewState) {
+        fooBottomSheetFragmentText.text = viewState.data
+    }
+
+}

--- a/demo/src/main/java/co/zsmb/rainbowcake/demo/ui/koin/KoinFragment.kt
+++ b/demo/src/main/java/co/zsmb/rainbowcake/demo/ui/koin/KoinFragment.kt
@@ -5,6 +5,7 @@ import android.view.View
 import co.zsmb.rainbowcake.base.RainbowCakeFragment
 import co.zsmb.rainbowcake.demo.R
 import co.zsmb.rainbowcake.koin.getViewModelFromFactory
+import kotlinx.android.synthetic.main.fragment_example.bottomSheetExampleDemoButton
 import kotlinx.android.synthetic.main.fragment_koin.*
 
 class KoinFragment : RainbowCakeFragment<KoinViewState, KoinViewModel>() {
@@ -17,6 +18,10 @@ class KoinFragment : RainbowCakeFragment<KoinViewState, KoinViewModel>() {
 
         textView.setOnClickListener {
             viewModel.load()
+        }
+
+        bottomSheetExampleDemoButton.setOnClickListener {
+            fragmentManager?.let { KoinBottomSheetFragment().show(it, "FooBottomSheetFragmentKoin") }
         }
     }
 

--- a/demo/src/main/res/layout/fragment_bottom_sheet_foo.xml
+++ b/demo/src/main/res/layout/fragment_bottom_sheet_foo.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/fooBottomSheetFragmentRoot"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:minHeight="200dp">
+
+    <TextView
+        android:id="@+id/fooBottomSheetFragmentText"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="FooBottomSheetFragment\n\n"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/demo/src/main/res/layout/fragment_example.xml
+++ b/demo/src/main/res/layout/fragment_example.xml
@@ -60,9 +60,21 @@
         android:layout_marginStart="8dp"
         android:layout_marginEnd="8dp"
         android:text="Koin based screen"
-        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintBottom_toTopOf="@+id/bottomSheetExampleDemoButton"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/viewBindingExampleDemoButton" />
+
+    <Button
+        android:id="@+id/bottomSheetExampleDemoButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginEnd="8dp"
+        android:text="Bottom sheet"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/koinExampleDemoButton" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/demo/src/main/res/layout/fragment_koin.xml
+++ b/demo/src/main/res/layout/fragment_koin.xml
@@ -15,4 +15,16 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
+    <Button
+        android:id="@+id/bottomSheetExampleDemoButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginEnd="8dp"
+        android:text="Bottom sheet"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/textView" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/rainbow-cake-core/build.gradle
+++ b/rainbow-cake-core/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'kotlin-android'
 dependencies {
     // Google libraries
     implementation 'androidx.appcompat:appcompat:1.2.0'
-    implementation 'com.google.android.material:material:1.2.1'
+    api 'com.google.android.material:material:1.2.1'
     implementation 'androidx.lifecycle:lifecycle-livedata-core-ktx:2.2.0'
     implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.2.0'
 

--- a/rainbow-cake-core/src/main/java/co/zsmb/rainbowcake/base/RainbowCakeBottomFragment.kt
+++ b/rainbow-cake-core/src/main/java/co/zsmb/rainbowcake/base/RainbowCakeBottomFragment.kt
@@ -1,0 +1,95 @@
+package co.zsmb.rainbowcake.base
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.annotation.CallSuper
+import androidx.annotation.LayoutRes
+import co.zsmb.rainbowcake.internal.logging.log
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+
+/**
+ * Base class for BottomSheetDialogFragments that connects them to the appropriate ViewModel instances.
+ */
+public abstract class RainbowCakeBottomFragment<VS : Any, VM : RainbowCakeViewModel<VS>> : BottomSheetDialogFragment() {
+
+    private val logTag: String by lazy(mode = LazyThreadSafetyMode.NONE) { "RainbowCakeBottomFragment ($this)" }
+
+    /**
+     * The ViewModel of this Fragment.
+     */
+    protected lateinit var viewModel: VM
+
+    @CallSuper
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        viewModel = provideViewModel()
+
+        viewModel.events.observe(this) { event ->
+            event?.let { onEvent(it) }
+        }
+        viewModel.queuedEvents.observe(this) { event ->
+            event?.let { onEvent(it) }
+        }
+    }
+
+    /**
+     * Calls to super for this method MAY be omitted if the View inflation needs
+     * to be customized. In these cases, [getViewResource] can return any value
+     * as it won't be used (recommendation: 0).
+     */
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        val viewResource = getViewResource()
+        require(viewResource != 0) {
+            "Override getViewResource to provide a layout resource ID, or override onCreateView to provide a layout directly"
+        }
+        return inflater.inflate(viewResource, container, false)
+    }
+
+    @CallSuper
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        viewModel.state.observe(viewLifecycleOwner) { viewState ->
+            viewState?.let { render(it) }
+        }
+    }
+
+    /**
+     * This method should return a ViewModel instance for the current Fragment.
+     *
+     * If one of RainbowCake's own DI libraries are being used, this method should
+     * return the result of a [getViewModelFromFactory] call.
+     */
+    protected abstract fun provideViewModel(): VM
+
+    /**
+     * Renders the view state. Called when the view state changes and the UI should be
+     * updated accordingly.
+     *
+     * Must be implemented in a way so that previous view states do not affect the current
+     * state of the UI. In other words, the same view state being set must always result
+     * in the same state for the displayed UI.
+     *
+     * @param viewState The new state of the ViewModel.
+     */
+    protected abstract fun render(viewState: VS)
+
+    /**
+     * Handles one-time events emitted by the ViewModel.
+     *
+     * @param event An event emitted by the ViewModel.
+     */
+    protected open fun onEvent(event: OneShotEvent) {
+        log(logTag, "Unhandled event: $event")
+    }
+
+    /**
+     * Returns the ID of the Fragment's layout resource to be inflated. If you need custom
+     * inflation logic for your Fragment, besides choosing a layout resource to inflate,
+     * override the [onViewCreated] method instead.
+     */
+    @LayoutRes
+    protected open fun getViewResource(): Int = 0
+}

--- a/rainbow-cake-dagger/src/main/java/co/zsmb/rainbowcake/dagger/RainbowCakeFragment.kt
+++ b/rainbow-cake-dagger/src/main/java/co/zsmb/rainbowcake/dagger/RainbowCakeFragment.kt
@@ -1,10 +1,11 @@
 package co.zsmb.rainbowcake.dagger
 
+import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
+import co.zsmb.rainbowcake.base.RainbowCakeBottomFragment
 import co.zsmb.rainbowcake.base.RainbowCakeFragment
 import co.zsmb.rainbowcake.base.RainbowCakeViewModel
 import co.zsmb.rainbowcake.base.ViewModelScope
-
 
 /**
  * Uses the ViewModelFactory from the [RainbowCakeComponent] inside the [RainbowCakeApplication] to
@@ -21,13 +22,28 @@ public inline fun <F : RainbowCakeFragment<VS, VM>, VS, reified VM : RainbowCake
             ?.viewModelFactory()
             ?: throw IllegalStateException("RainbowCakeFragment should not be used without an Application that inherits from RainbowCakeApplication")
 
+    return getFragmentViewModel(scope, viewModelFactory)
+}
+
+public inline fun <F : RainbowCakeBottomFragment<VS, VM>, VS, reified VM : RainbowCakeViewModel<VS>> F.getViewModelFromFactory(
+        scope: ViewModelScope = ViewModelScope.Default
+): VM {
+    val viewModelFactory = (getContext()?.applicationContext as? RainbowCakeApplication)
+            ?.injector
+            ?.viewModelFactory()
+            ?: throw IllegalStateException("RainbowCakeBottomFragment should not be used without an Application that inherits from RainbowCakeApplication")
+
+    return getFragmentViewModel(scope, viewModelFactory)
+}
+
+public inline fun <VS, reified VM : RainbowCakeViewModel<VS>> Fragment.getFragmentViewModel(scope: ViewModelScope, viewModelFactory: ViewModelProvider.Factory): VM {
     return when (scope) {
         ViewModelScope.Default -> {
             ViewModelProvider(this, viewModelFactory).get(VM::class.java)
         }
         is ViewModelScope.ParentFragment -> {
             val parentFragment = getParentFragment()
-                    ?: throw IllegalStateException("No parent Fragment")
+                ?: throw IllegalStateException("No parent Fragment")
             val key = scope.key
             if (key != null) {
                 ViewModelProvider(parentFragment, viewModelFactory).get(key, VM::class.java)

--- a/rainbow-cake-koin/src/main/java/co/zsmb/rainbowcake/koin/RainbowCakeFragment.kt
+++ b/rainbow-cake-koin/src/main/java/co/zsmb/rainbowcake/koin/RainbowCakeFragment.kt
@@ -1,5 +1,7 @@
 package co.zsmb.rainbowcake.koin
 
+import androidx.fragment.app.Fragment
+import co.zsmb.rainbowcake.base.RainbowCakeBottomFragment
 import co.zsmb.rainbowcake.base.RainbowCakeFragment
 import co.zsmb.rainbowcake.base.RainbowCakeViewModel
 import co.zsmb.rainbowcake.base.ViewModelScope
@@ -18,13 +20,23 @@ import org.koin.core.qualifier.named
 public inline fun <F : RainbowCakeFragment<VS, VM>, VS, reified VM : RainbowCakeViewModel<VS>> F.getViewModelFromFactory(
         scope: ViewModelScope = Default
 ): VM {
+    return getFragmentViewModel(scope)
+}
+
+public inline fun <F : RainbowCakeBottomFragment<VS, VM>, VS, reified VM : RainbowCakeViewModel<VS>> F.getViewModelFromFactory(
+        scope: ViewModelScope = Default
+): VM {
+    return getFragmentViewModel(scope)
+}
+
+public inline fun <VS, reified VM : RainbowCakeViewModel<VS>> Fragment.getFragmentViewModel(scope: ViewModelScope): VM {
     return when (scope) {
         Default -> {
             this.getViewModel()
         }
         is ParentFragment -> {
             val parentFragment = getParentFragment()
-                    ?: throw IllegalStateException("No parent Fragment")
+                ?: throw IllegalStateException("No parent Fragment")
             val key = scope.key
             if (key != null) {
                 parentFragment.getViewModel(named(key))


### PR DESCRIPTION
Hi, I am using RainbowCake to rework from scratch an application for my enterprise, and I am facing this same issue https://github.com/rainbowcake/rainbowcake/issues/21

One of the most reason I use RainbowCake is the UI Render/State handling (great job!), so I'd like to use this mechanism in BottomSheetDialogFragment with RainbowCakeViewModel + Dagger.
Maybe we'll can extend this to DialogFragment too.

I know this come with little duplications, but I don't know how to do differently for now.

Feel free to make any feedback or any change !