### PR TITLE
The koin project's maven group id has changed

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,6 @@ buildscript {
     repositories {
         google()
         mavenCentral()
-        jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.1.1'
@@ -28,7 +27,6 @@ allprojects {
     repositories {
         google()
         mavenCentral()
-        jcenter()
     }
 }
 

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -50,7 +50,7 @@ dependencies {
     kapt "com.google.dagger:dagger-compiler:$dagger_version"
 
     // Koin
-    implementation "org.koin:koin-core:$koin_version"
-    implementation "org.koin:koin-android:$koin_version"
-    implementation "org.koin:koin-android-viewmodel:$koin_version"
+    implementation "io.insert-koin:koin-core:$koin_version"
+    implementation "io.insert-koin:koin-android:$koin_version"
+    implementation "io.insert-koin:koin-android-viewmodel:$koin_version"
 }

--- a/rainbow-cake-koin/build.gradle
+++ b/rainbow-cake-koin/build.gradle
@@ -10,9 +10,9 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 
     // Koin
-    implementation "org.koin:koin-core:$koin_version"
-    implementation "org.koin:koin-android:$koin_version"
-    implementation "org.koin:koin-android-viewmodel:$koin_version"
+    implementation "io.insert-koin:koin-core:$koin_version"
+    implementation "io.insert-koin:koin-android:$koin_version"
+    implementation "io.insert-koin:koin-android-viewmodel:$koin_version"
 }
 
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {


### PR DESCRIPTION
The koin project's maven group id was previously `org.koin` and is now `io.insert-koin`.
Also, the `jcenter()` repository is being shut down so I've removed it.

Reference: [github.com/InsertKoinIO](https://github.com/InsertKoinIO/koin#the-koin-projects-maven-group-id-was-previously-orgkoin-its-now-ioinsert-koin-on-maven-central)